### PR TITLE
Changes/correctiosn to Sec. 4

### DIFF
--- a/exploring-v7/exploring.tex
+++ b/exploring-v7/exploring.tex
@@ -20,6 +20,8 @@
 % the following package is optional:
 %\usepackage{latexsym}
 
+\usepackage{enumitem}
+
 \hyphenation{data-log}
 
 % Following comment is from ijcai97-submit.tex:
@@ -65,9 +67,9 @@ Materialization is an important reasoning service for applications built on the 
 
 
 \section{Introduction}
-The Web Ontology Language OWL\footnote{The latest version is OWL 2, http://www.w3.org/TR/owl2-overview/} is an important standard for ontology languages in the Semantic Web and other application areas. \emph{Materialization} is a basic service for computing all implicit facts that follow from a given OWL ontology. Due to the generation of data by sensor networks, social media and organizations, there is an exponential growth of semantic data \cite{DBLP:conf/wims/MeuselBP15}. Thus it is challenging to perform materialization on such large-scale ontologies efficiently.
+The Web Ontology Language OWL\footnote{The latest version is OWL 2, http://www.w3.org/TR/owl2-overview/} is an important standard for ontology languages in the Semantic Web and other application areas. \emph{Materialization} is a basic service for computing all implicit facts that follow from a given OWL ontology. Due to the generation of data by sensor networks, social media and organizations, there is an exponential growth of semantic data \cite{DBLP:conf/wims/MeuselBP15}. Thus, it is challenging to perform materialization on such large-scale ontologies efficiently.
 
-To make materialization sufficiently efficient and scalable in practice, many works employ parallel reasoning systems. For example, RDFox \cite{DBLP:conf/aaai/MotikNPHO14} is a parallel implementation for materialization of datalog rewritable ontology languages. WebPIE \cite{DBLP:journals/ws/UrbaniKMHB12} and Marvin \cite{oren2009marvin} are two distributed systems for reasoning in RDFS (and its extensions). There are also works that use parallel techniques to achieve scalable reasoning for highly expressive ontology languages \cite{DBLP:conf/dlog/SchlichtS08,DBLP:conf/dlog/WuH12}. However, according to \citeauthor{RAYMOND-GREENLAW} \shortcite{RAYMOND-GREENLAW}, even for RDFS and datalog rewritable ontology languages, which have PTime-complete or higher complexity\footnote{We consider the data complexity for materialization here.} of reasoning in the worst case, they are not parallelly tractable, i.e., reasoning may be inherently sequential even on a parallel implementations. On the other hand, some well-known large-scale ontologies, such as YAGO, have been shown to have good performance for parallel reasoning \cite{DBLP:conf/icde/SundaraAKDWCS10}, but they are expressed in ontology languages that are not parallelly tractable. The theoretical results on the complexity of ontology languages can hardly explain this. Thus % we aim at studying the problem of making materialization efficient not from the point of ontology languages, but from the angle of data. That is, 
+To make materialization sufficiently efficient and scalable in practice, many works employ parallel reasoning systems. For example, RDFox \cite{DBLP:conf/aaai/MotikNPHO14} is a parallel implementation for materialization of datalog rewritable ontology languages. WebPIE \cite{DBLP:journals/ws/UrbaniKMHB12} and Marvin \cite{oren2009marvin} are two distributed systems for reasoning in RDFS (and its extensions). There are also works that use parallel techniques to achieve scalable reasoning for highly expressive ontology languages \cite{DBLP:conf/dlog/SchlichtS08,DBLP:conf/dlog/WuH12}. However, according to \citeauthor{RAYMOND-GREENLAW} \shortcite{RAYMOND-GREENLAW}, even for RDFS and datalog rewritable ontology languages, which have PTime-complete or higher complexity\footnote{We consider the data complexity for materialization here.} of reasoning in the worst case, they are not parallelly tractable, i.e., reasoning may be inherently sequential even on a parallel implementations. On the other hand, some well-known large-scale ontologies, such as YAGO, have been shown to have good performance for parallel reasoning \cite{DBLP:conf/icde/SundaraAKDWCS10}, but they are expressed in ontology languages that are not parallelly tractable. The theoretical results on the complexity of ontology languages can hardly explain this. Thus, % we aim at studying the problem of making materialization efficient not from the point of ontology languages, but from the angle of data. That is, 
 we aim at identifying what kinds of ontologies make the task of materialization parallelly tractable. While one can try out different parallel implementations to see whether an ontology can be handled by (one of) them efficiently, the aim of our study is to identify theoretical properties that make an ontology parallelly tractable and that can guide ontology engineers in creating large-scale ontologies that can still be handled efficiently. 
 
 According to \citeauthor{DBLP:conf/aaai/MotikNPHO14} \shortcite{DBLP:conf/aaai/MotikNPHO14}, many real large-scale ontologies are essentially expressed in the ontology languages that can be rewritten into datalog rules. In this paper, we focus on such datalog rewritable ontology languages.
@@ -155,7 +157,7 @@ denoted by $|\mathcal{G}|$, is the number of nodes in $\mathcal{G}$. The depth o
 Consider a DHL ontology where the TBox is $\{$$A\sqsubseteq\forall R.A$, $R\circ S\sqsubseteq R$$\}$ and the ABox contains several assertions $\{$$A(a),R(a,b_1),S(b_i,b_{i+1})$$\}$ for $1\leq i\leq k-1$ and $k$ is an integer greater than $1$. The corresponding datalog program of this ontology is $P_{exp}=\langle\mathcal{O}, R\rangle$ where $\mathcal{O}$ is the ABox and $R$ contains the two rules `$A(y)\leftarrow A(x),R(x,y)$' and `$R(x,z)\leftarrow R(x,y),S(y,z)$'. The graph in Figure~\ref{fig:mg} is a materialization graph with respect to $P_{exp}$, denoted by $\mathcal{G}_{exp}$. The explicit nodes whose fan-in is 0 are the original facts in $\mathcal{O}$. Each of the implicit nodes corresponds to a ground instantiation of some rule. For example, the node $A(b_k)$ corresponds to the ground rule instantiation `$A(b_k)\leftarrow A(a),R(a,b_k)$'. The size of this materialization graph is the number of the nodes, that is $3k$. The depth of $\mathcal{G}_{exp}$ is $k+1$.
 \end{example}
 
-We say that a materialization graph $\mathcal{G}$ is a \emph{complete materialization graph} when $\mathcal{G}$ contains all ground atoms in $T_R^{\omega}(\mathcal{O})$. The set of nodes in a complete materialization graph is actually the result of materialization. Thus the procedure of materialization
+We say that a materialization graph $\mathcal{G}$ is a \emph{complete materialization graph} when $\mathcal{G}$ contains all ground atoms in $T_R^{\omega}(\mathcal{O})$. The set of nodes in a complete materialization graph is actually the result of materialization. Thus, the procedure of materialization
 can be transformed to the construction of a complete materialization graph. We pay our attention to complete materialization graphs and do not distinguish it to the notion `materialization graph'. It should also be noted that there may exist several materialization graphs for a datalog program.
 
 \textbf{A Naive Parallel Algorithm}. In this part, we propose a naive parallel algorithm (Algorithm~1) that constructs a materialization graph for a given datalog program.\\
@@ -165,31 +167,33 @@ returns a materialization graph $\mathcal{G}$ of $P$. Recall that $P^*$ denotes 
 which consists of all possible ground instantiations of rules in $R$. Suppose we have
 $|P^*|$ processors,\footnote{This might not be practically feasible, but we focus on a theoretical analysis here.} and each rule instantiation in $P^*$ is assigned to one processor.
 Initially $\mathcal{G}$ is empty. The following three steps are then performed:
-
-(\emph{Step~1}) Add all facts in $\mathcal{O}$ to $\mathcal{G}$.
-
-(\emph{Step~2}) For each rule instantiation $H\leftarrow B_1,...,B_n$, if the body atoms are all in $\mathcal{G}$ while $H$ is not in $\mathcal{G}$,\footnote{Suppose that each processor can use $O(1)$ time to access the state of ground atom, i.e., whether this ground atom has been added to the materialization graph. This can be implemented by maintaining an
+\begin{enumerate}[leftmargin=8ex,label=(\textit{Step \arabic*}),ref=Step~\arabic*]
+\item Add all facts in $\mathcal{O}$ to $\mathcal{G}$.\label{alg1:addFacts}
+\item For each rule instantiation $H\leftarrow B_1,...,B_n$, if the body atoms are all in $\mathcal{G}$ while $H$ is not in $\mathcal{G}$,\footnote{Suppose that each processor can use $O(1)$ time to access the state of ground atom, i.e., whether this ground atom has been added to the materialization graph. This can be implemented by maintaining an
 index of polynomial size.}
-the corresponding processor adds $H$ to $\mathcal{G}$ and creates edges pointing from $B_1,...,B_n$ to $H$.
-
-(\emph{Step~3}) If no processor that can add more nodes and edges to $\mathcal{G}$ terminate, otherwise iterate Step~2.\hfill$\Box$\\
+the corresponding processor adds $H$ to $\mathcal{G}$ and creates edges pointing from $B_1,...,B_n$ to $H$.\label{alg1:updateG}
+\item If no processor that can add more nodes and edges to $\mathcal{G}$ terminate, otherwise iterate \ref{alg1:updateG}.\label{alg1:halt}\hfill$\Box$
+\end{enumerate}
 
 \begin{example}
-We consider the datalog program $P_{exp}$ in Example~1 again, and perform Algorithm~1 on it. Initially, all the facts
-($A(a),R(a,b_1),S(b_1,b_2),...,S(b_{k-1},b_{k})$) are added to the result $\mathcal{G}_{exp}$ (Step~1). Then in different iterations of Step~2, the remaining nodes are inserted into
-$\mathcal{G}_{exp}$ by different processors. For example a processor $p$ is allocated a rule instantiation `$A(b_2)\leftarrow A(a),R(a,b_2)$'. Then, processor $p$ adds $A(b_2)$ to $\mathcal{G}_{exp}$ after it checks that $A(a)$ and $R(a,b_2)$ are in $\mathcal{G}_{exp}$. Algorithm~1 halts when $A(b_k)$ has been added to $\mathcal{G}_{exp}$ (Step~3).
+We consider the datalog program $P_{exp}$ in Example~\ref{exp:mg} again, and perform Algorithm~1 on it. Initially, all the facts
+($A(a),R(a,b_1),S(b_1,b_2),...,S(b_{k-1},b_{k})$) are added to the result $\mathcal{G}_{exp}$ \ref{alg1:addFacts}. Then in different iterations of \ref{alg1:updateG}, the remaining nodes are inserted into
+$\mathcal{G}_{exp}$ by different processors. For example a processor $p$ is allocated a rule instantiation `$A(b_2)\leftarrow A(a),R(a,b_2)$'. Then, processor $p$ adds $A(b_2)$ to $\mathcal{G}_{exp}$ after it checks that $A(a)$ and $R(a,b_2)$ are in $\mathcal{G}_{exp}$. Algorithm~1 halts when $A(b_k)$ has been added to $\mathcal{G}_{exp}$ \ref{alg1:halt}.
 \end{example}
 
 Lemma~\ref{lemma:a1} shows the correctness of Algorithm~1 and that, for any datalog program $P$, Algorithm~1 always constructs a materialization graph with the minimum depth among all the materialization graphs of $P$.
 
 \begin{lemma}\label{lemma:a1}
-Given a datalog program $P=\langle\mathcal{O}, R\rangle$, we have (1) Algorithm~1 halts and returns a materialization graph $\mathcal{G}$ of $P$; (2) $\mathcal{G}$ has the the minimum depth among all the materialization graphs of $P$.
+Given a datalog program $P=\langle\mathcal{O}, R\rangle$, we have
+\begin{enumerate}
+\item Algorithm~1 halts and returns a materialization graph $\mathcal{G}$ of $P$; \item $\mathcal{G}$ has the the minimum depth among all the materialization graphs of $P$.
+\end{enumerate}
 \end{lemma}
 
-We next discuss how Algorithm~1 can be restricted to an \texttt{NC} version. (\uppercase\expandafter{\romannumeral1}) Since we do not allow introducing new constants during materialization and each predicate has a constant arity, one can check that $|P^*|$ is polynomial in the size\footnote{The size of $P$ can be seen as the number of characters used to encode $P$.} of $P$. This also means that the number of processors is polynomially bounded. (\uppercase\expandafter{\romannumeral2}) The computing time of Step~1 and Step~3 occupies constant time units because of parallelism. (\uppercase\expandafter{\romannumeral3}) The main computation part in Algorithm~1 is the iteration of Step~2. In each cycle of Step~2, all processors work independently from each other. Thus, in theory, Step~2 costs one time unit. The whole computing time turns out to be bounded by the number of iterations of Step~2. (\uppercase\expandafter{\romannumeral4})
-We now introduce a function $\psi$ that is poly-logarithmically bounded.  The input of $\psi$ is the size of $P$ and the output is an non-negative integer. Based on (\uppercase\expandafter{\romannumeral1},\uppercase\expandafter{\romannumeral2},
-\uppercase\expandafter{\romannumeral3},\uppercase\expandafter{\romannumeral4}), for any datalog program $P$, if we use $\psi(|P|)$ to
-bound the number of iterations of Step~2, then Algorithm~1 is an \texttt{NC} algorithm, denoted by $\mathcal{A}_1^{\psi}$.
+We next discuss how Algorithm~1 can be restricted to an \texttt{NC} version. (\uppercase\expandafter{\romannumeral1}) Since we do not allow introducing new constants during materialization and each predicate has a constant arity, one can check that $|P^*|$ is polynomial in the size\footnote{The size of $P$ can be seen as the number of characters used to encode $P$.} of $P$. This also means that the number of processors is polynomially bounded. (\uppercase\expandafter{\romannumeral2}) The computing time of \ref{alg1:addFacts} and \ref{alg1:halt} occupies constant time units because of parallelism. (\uppercase\expandafter{\romannumeral3}) The main computation part in Algorithm~1 is the iteration of \ref{alg1:updateG}. In each iteration of \ref{alg1:updateG}, all processors work independently from each other. Thus, in theory, \ref{alg1:updateG} costs one time unit. The whole computing time turns out to be bounded by the number of iterations of \ref{alg1:updateG}. (\uppercase\expandafter{\romannumeral4})
+We now introduce a function $\psi$ that is poly-logarithmically bounded.  The input of $\psi$ is the size of $P$ and the output is an non-negative integer. Based on (\uppercase\expandafter{\romannumeral1}, \uppercase\expandafter{\romannumeral2},
+\uppercase\expandafter{\romannumeral3}, \uppercase\expandafter{\romannumeral4}), for any datalog program $P$, if we use $\psi(|P|)$ to
+bound the number of iterations of \ref{alg1:updateG}, then Algorithm~1 is an \texttt{NC} algorithm, denoted by $\mathcal{A}_1^{\psi}$.
 
 Based on $\mathcal{A}_1^{\psi}$, we can identify a class of datalog programs $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ where all the datalog programs can be handled by $\mathcal{A}_1^{\psi}$. It is obvious that $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ is a \texttt{PTD} class.
 
@@ -199,50 +203,68 @@ We further show that $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ can be captured in ter
 For any datalog program $P$, $P\in\mathcal{D}_{\mathcal{A}_1^{\psi}}$ iff $P$ has a materialization graph whose depth is upper-bounded by $\psi(|P|)$.
 \end{theorem}
 
-$\mathcal{A}_1^{\psi}$ is restricted in the sense that it cannot even work on the rather simple datalog program $P_{exp}$ in Example~1. The graph $\mathcal{G}_{exp}$ in Figure~\ref{fig:mg} is the unique materialization graph of $P_{exp}$. One can also check that \texttt{depth}($\mathcal{G}_{exp}$)$=k+1$. This means that the depth of $\mathcal{G}_{exp}$ is linearly bounded by $k$. On the other hand, the size of $P_{exp}$ can be captured by $k$. Thus, for any $\psi$ that is poly-logarithmically bounded, we can always find a $k$  large enough such that $\mathcal{A}_1^{\psi}$ terminates without constructing a materialization graph of $P_{exp}$. However there indeed exists an \texttt{NC} algorithm that can handle $P_{exp}$. We discuss this in the next section.
+$\mathcal{A}_1^{\psi}$ is restricted in the sense that it cannot even work on the rather simple datalog program $P_{exp}$ in Example~\ref{exp:mg}. The graph $\mathcal{G}_{exp}$ in Figure~\ref{fig:mg} is the unique materialization graph of $P_{exp}$. One can also check that \texttt{depth}($\mathcal{G}_{exp}$)$=k+1$. This means that the depth of $\mathcal{G}_{exp}$ is linearly bounded by $k$. On the other hand, the size of $P_{exp}$ can be captured by $k$. Thus, for any $\psi$ that is poly-logarithmically bounded, we can always find a $k$  large enough such that $\mathcal{A}_1^{\psi}$ terminates without constructing a materialization graph of $P_{exp}$. However there indeed exists an \texttt{NC} algorithm that can handle $P_{exp}$. We discuss this in the next section.
 
 \section{An Optimized \texttt{NC} Algorithm}
 
 In this section, we optimize Algorithm~1 such that $P_{exp}$
 can be handled. Based on the optimized variant of Algorithm~1, we can identify other \texttt{PTD} classes.
 
-For Example~1, the construction of the materialization graph can be accelerated. Using Algorithm~1, $A(b_k)$ is added to $\mathcal{G}_{exp}$ after \emph{at least} $k$ iterations. Observe that $A(b_k)$ is reachable from $R(a,b_1)$ through the path $(R(a,b_1),R(a,b_2),...,R(a,b_k))$. On the one hand, each node $R(a,b_i)$ ($2\leq i\leq k$) can be added to $\mathcal{G}_{exp}$ whenever its parent $R(a,b_{i-1})$ is in $\mathcal{G}$, since $R(a,b_i)$ is an SWD node, i.e., $R(a,b_{i-1})$ is the unique implicit parent node of $R(a,b_{i})$ (see the paragraph after Definition 2). On the other hand, $R(a,b_1)$ is initially added to $\mathcal{G}_{exp}$. Thus, one can add all the nodes $R(a,b_i)$ ($2\leq i\leq k$) and $A(b_k)$ to $\mathcal{G}_{exp}$ right after $R(a,b_1)$. Based on this observation, we optimize Algorithm~1 using the following strategy:
+For Example~\ref{exp:mg}, the construction of the materialization graph can be accelerated. Using Algorithm~1, $A(b_k)$ is added to $\mathcal{G}_{exp}$ after \emph{at least} $k$ iterations. Observe that $A(b_k)$ is reachable from $R(a,b_1)$ through the path $(R(a,b_1),R(a,b_2),...,R(a,b_k))$. On the one hand, each node $R(a,b_i)$ ($2\leq i\leq k$) can be added to $\mathcal{G}_{exp}$ whenever its parent $R(a,b_{i-1})$ is in $\mathcal{G}$, since $R(a,b_i)$ is an SWD node, i.e., $R(a,b_{i-1})$ is the unique implicit parent node of $R(a,b_{i})$ (see the paragraph after Definition~\ref{def:mg}). On the other hand, $R(a,b_1)$ is initially added to $\mathcal{G}_{exp}$. Thus, one can add all the nodes $R(a,b_i)$ ($2\leq i\leq k$) and $A(b_k)$ to $\mathcal{G}_{exp}$ right after $R(a,b_1)$. Based on this observation, we optimize Algorithm~1 using the following strategy:
 
-(\textbf{Strategy}) \emph{In every iteration of Step~2, for each SWD node $v$, we add $v$ to $\mathcal{G}$ immediately if $v$ is reachable from some node that has been in $\mathcal{G}$ through a path containing only SWD nodes}.
+(\textbf{Strategy}) \emph{In every iteration of \ref{alg1:updateG}, for each SWD node $v$, we add $v$ to $\mathcal{G}$ immediately if $v$ is reachable from some node that has been in $\mathcal{G}$ through a path containing only SWD nodes}.
 
 To describe the reachability between two nodes, we use a
-binary transitive relation \texttt{rch}$\subseteq T_R^{\omega}(\mathcal{O})\times T_R^{\omega}(\mathcal{O})$, e.g.,
-\texttt{rch}$(v_1,v_2)$ means $v_2$ is reachable from $v_1$. In each cycle of Step~2, we compute a \texttt{rch}
-relation (denoted by $S_{\tiny rch}$) by performing the following process:
+binary transitive relation $\texttt{rch} \subseteq T_R^{\omega}(\mathcal{O})\times T_R^{\omega}(\mathcal{O})$, e.g.,
+\texttt{rch}$(v_1,v_2)$ means $v_2$ is reachable from $v_1$. In each iteration of \ref{alg1:updateG}, we compute a \texttt{rch}
+relation (denoted by $S_{\textit{\tiny rch}}$) by performing the following process:
+\begin{description}[leftmargin=4ex]
+\item[(\textbf{\dag})] \emph{For each rule instantiation $H\leftarrow B_1,..,B_i,..,B_n$ where $H$ is not in $\mathcal{G}$}:
+\begin{enumerate}
+\item \emph{if the body atoms $B_1,...,B_n$ are all in $\mathcal{G}$, add \texttt{rch}$(B_1,H),...,$\texttt{rch}$(B_n,H)$ to $S_{\textit{\tiny rch}}$};
+\item \emph{if $B_i$ is the unique implicit node in the body and not yet in $\mathcal{G}$, add \texttt{rch}$(B_i,H)$ to $S_{\textit{\tiny rch}}$}.\hfill$\Box$
+\end{enumerate}
+\end{description}
+% $(\textbf{\dag})$ \emph{For each rule instantiation $H\leftarrow B_1,..,B_i,..,B_n$ where $H$ is not in $\mathcal{G}$}:
 
-$(\textbf{\dag})$ \emph{For each rule instantiation $H\leftarrow B_1,..,B_i,..,B_n$ where $H$ is not in $\mathcal{G}$}:
+% \emph{(1) if the body atoms $B_1,...,B_n$ are all in $\mathcal{G}$, we add \texttt{rch}$(B_1,H),...,$\texttt{rch}$(B_n,H)$ to $S_{\textit{\tiny rch}}$};
 
-\emph{(1) if the body atoms $B_1,...,B_n$ are all in $\mathcal{G}$, we add \texttt{rch}$(B_1,H),...,$\texttt{rch}$(B_n,H)$ to $S_{\tiny rch}$};
+% \emph{(2) if in the body, $B_i$ is the unique implicit node and not yet in $\mathcal{G}$, we add \texttt{rch}$(B_i,H)$ to $S_{\textit{\tiny rch}}$}.\hfill$\Box$
 
-\emph{(2) if in the body, $B_i$ is the unique implicit node and not yet in $\mathcal{G}$, we add \texttt{rch}$(B_i,H)$ to $S_{\tiny rch}$}.\hfill$\Box$
-
-We then compute the transitive closure of \texttt{rch} with respect to $S_{\tiny rch}$. From the transitive closure, we can identify such SWD nodes that can be added to $\mathcal{G}$ in advance. The following algorithm applies this optimization strategy:\\
+We then compute the transitive closure of \texttt{rch} with respect to $S_{\textit{\tiny rch}}$. From the transitive closure, we can identify such SWD nodes that can be added to $\mathcal{G}$ in advance. The following algorithm applies this optimization strategy:\\
 
 \noindent\texttt{Algorithm~2}. The algorithm requires two inputs: a datalog program $P=\langle\mathcal{O}, R\rangle$ and a (partial) materialization graph $\mathcal{G}$ that is constructed from $P$. Then the following steps are performed:
+\begin{enumerate}[label=(\textbf{\roman*})]
+\item Compute a \texttt{rch} relation $S_{\textit{\tiny rch}}$ by following the above process (see $(\textbf{\dag})$).\label{rch}
+%\item Compute the transitive closure of $S_{\textit{\tiny rch}}$ and gets a new one $S^*_{\textit{\tiny rch}}$.
+\item Compute the transitive closure $S^*_{\textit{\tiny rch}}$ of $S_{\textit{\tiny rch}}$.\label{transClos}
+\item Update $\mathcal{G}$ as follows: for any \texttt{rch}$(B_i,H)\in S_{\textit{\tiny rch}}$ that corresponds to $H\leftarrow B_1,..,B_i,..,B_n$
+such that \texttt{rch}$(B',H)$,\texttt{rch}$(B'',B_i)\in S^*_{\textit{\tiny rch}}$ where $B',B''$ are in $\mathcal{G}$; If $H$ is not in $\mathcal{G}$ or $H$ is in $\mathcal{G}$ but has no parent pointing to it, add $H$ and $B_i$ (if $B_i$ is not in $\mathcal{G}$) to $\mathcal{G}$, and create the edges $e(B_1, H),...,e(B_n, H)$ in $\mathcal{G}$. Do nothing for other statements \texttt{rch}$(B_j,H)\in S_{\textit{\tiny rch}}$.\label{updateG}\hfill$\Box$
+\end{enumerate}
 
-(\textbf{\romannumeral1}) Compute a \texttt{rch} relation $S_{\tiny rch}$ by following the above process (see $(\textbf{\dag})$).
+% (\textbf{\romannumeral1}) Compute a \texttt{rch} relation $S_{\textit{\tiny rch}}$ by following the above process (see $(\textbf{\dag})$).
 
-% (\textbf{\romannumeral2}) Compute the transitive closure of $S_{\tiny rch}$ and gets a new one $S^*_{\tiny rch}$.
-(\textbf{\romannumeral2}) Compute the transitive closure $S^*_{\tiny rch}$ of $S_{\tiny rch}$.
+% % (\textbf{\romannumeral2}) Compute the transitive closure of $S_{\textit{\tiny rch}}$ and gets a new one $S^*_{\textit{\tiny rch}}$.
+% (\textbf{\romannumeral2}) Compute the transitive closure $S^*_{\textit{\tiny rch}}$ of $S_{\textit{\tiny rch}}$.
 
-(\textbf{\romannumeral3}) Update $\mathcal{G}$ as follows: for any \texttt{rch}$(B_i,H)\in S_{\tiny rch}$ that corresponds to $H\leftarrow B_1,..,B_i,..,B_n$
-such that \texttt{rch}$(B',H)$,\texttt{rch}$(B'',B_i)\in S^*_{\tiny rch}$ where $B',B''$ are in $\mathcal{G}$; If $H$ is not in $\mathcal{G}$ or $H$ is in $\mathcal{G}$ but has no parent pointing to it, add $H$ and $B_i$ (if $B_i$ is not in $\mathcal{G}$) to $\mathcal{G}$, and create the edges $e(B_1, H),...,e(B_n, H)$ in $\mathcal{G}$. Do nothing for other statements \texttt{rch}$(B_j,H)\in S_{\tiny rch}$.\hfill$\Box$\\
+% (\textbf{\romannumeral3}) Update $\mathcal{G}$ as follows: for any \texttt{rch}$(B_i,H)\in S_{\textit{\tiny rch}}$ that corresponds to $H\leftarrow B_1,..,B_i,..,B_n$
+% such that \texttt{rch}$(B',H)$,\texttt{rch}$(B'',B_i)\in S^*_{\textit{\tiny rch}}$ where $B',B''$ are in $\mathcal{G}$; If $H$ is not in $\mathcal{G}$ or $H$ is in $\mathcal{G}$ but has no parent pointing to it, add $H$ and $B_i$ (if $B_i$ is not in $\mathcal{G}$) to $\mathcal{G}$, and create the edges $e(B_1, H),...,e(B_n, H)$ in $\mathcal{G}$. Do nothing for other statements \texttt{rch}$(B_j,H)\in S_{\textit{\tiny rch}}$.\hfill$\Box$\\
 
 It is well known that there is an \texttt{NC} algorithm for computing the transitive closure \cite{DBLP:conf/cie/Allender07}. Based on this result and Algorithm~2, we propose a variant of Algorithm~1:\\
 
 \noindent\texttt{Algorithm~3}. Given a datalog program $P=\langle\mathcal{O}, R\rangle$, the algorithm
 returns a materialization graph $\mathcal{G}$ of $P$. Initially $\mathcal{G}$ is empty. The following steps are then performed:
+\begin{enumerate}[leftmargin=8ex,label=(\textit{Step \arabic*}),ref=Step~\arabic*]
+\item Add all facts in $\mathcal{O}$ to $\mathcal{G}$.\label{alg3:addFacts}
+\item Compute $S_{\textit{\tiny rch}}$ by performing \ref{rch} in Algorithm~2; use an \texttt{NC} algorithm to compute the transitive closure $S^*_{\textit{\tiny rch}}$ (see \ref{transClos} in Algorithm~2); update $\mathcal{G}$ by performing \ref{updateG}  in Algorithm~2.\label{alg3:updateG}
+\item If no nodes can be added to $\mathcal{G}$ termine, otherwise iterate \ref{alg3:updateG}. \label{alg3:halt}\hfill$\Box$
+\end{enumerate}
 
-(\emph{Step~1}) Add all facts in $\mathcal{O}$ to $\mathcal{G}$.
+% (\emph{Step~1}) Add all facts in $\mathcal{O}$ to $\mathcal{G}$.
 
-(\emph{Step~2}) Compute $S_{\tiny rch}$ by performing (\textbf{\romannumeral1}) in Algorithm~2; use an \texttt{NC} algorithm to compute the transitive closure $S^*_{\tiny rch}$ (see (\textbf{\romannumeral2}) in Algorithm~2); update $\mathcal{G}$ by performing (\textbf{\romannumeral3}) in Algorithm~2.
+% (\emph{Step~2}) Compute $S_{\textit{\tiny rch}}$ by performing (\textbf{\romannumeral1}) in Algorithm~2; use an \texttt{NC} algorithm to compute the transitive closure $S^*_{\textit{\tiny rch}}$ (see (\textbf{\romannumeral2}) in Algorithm~2); update $\mathcal{G}$ by performing (\textbf{\romannumeral3}) in Algorithm~2.
 
-(\emph{Step~3}) If no nodes can be added to $\mathcal{G}$ termine, otherwise iterate Step~2.\hfill$\Box$\\
+% (\emph{Step~3}) If no nodes can be added to $\mathcal{G}$ termine, otherwise iterate Step~2.\hfill$\Box$\\
 
 The following lemma shows the correctness of Algorithm~3.
 
@@ -251,12 +273,12 @@ Given a datalog program $P=\langle\mathcal{O}, R\rangle$, Algorithm~3 halts and 
 \end{lemma}
 
 \begin{example}
-We perform Algorithm~3 on the datalog program $P_{exp}$ in Example~1. Initially, $R(a,b_1)$ is in the materialization graph $\mathcal{G}_{exp}$. In the first iteration of Step~2, all the rule instantiations are in two kinds of forms: `$A(b_{i})\leftarrow A(a),R(a,b_{i})$' and `$R(a,b_i)\leftarrow R(a,b_{i-1}),S(b_{i-1},b_i)$' $(2\leq i\leq k)$, $S_{\tiny rch}$ is the set $\{$\texttt{rch}$(R(a,b_{i-1}), R(a,b_i))|2\leq i\leq k\}\cup\{$\texttt{rch}$(R(a,b_i), A(b_i))|1\leq i\leq k\}$. In the transitive closure of $S_{\tiny rch}$,
-one can check that \texttt{rch}$(R(a,b_1), R(a,b_i)),$\texttt{rch}$(R(a,b_1), A(b_i))\in S^*_{\tiny rch}(2\leq i\leq k)$. Thus $R(a,b_i)$ and $A(b_i)$ ($2\leq i\leq k$) can all be added to $\mathcal{G}_{exp}$ in the first iteration of Step~2.
+We perform Algorithm~3 on the datalog program $P_{exp}$ in Example~\ref{exp:mg}. Initially, $R(a,b_1)$ is in the materialization graph $\mathcal{G}_{exp}$. In the first iteration of \ref{alg3:updateG}, all the rule instantiations are in two kinds of forms: `$A(b_{i})\leftarrow A(a),R(a,b_{i})$' and `$R(a,b_i)\leftarrow R(a,b_{i-1}),S(b_{i-1},b_i)$' $(2\leq i\leq k)$, $S_{\textit{\tiny rch}}$ is the set $\{$\texttt{rch}$(R(a,b_{i-1}), R(a,b_i))|2\leq i\leq k\}\cup\{$\texttt{rch}$(R(a,b_i), A(b_i))|1\leq i\leq k\}$. In the transitive closure of $S_{\textit{\tiny rch}}$,
+one can check that \texttt{rch}$(R(a,b_1), R(a,b_i)),$\texttt{rch}$(R(a,b_1), A(b_i))\in S^*_{\textit{\tiny rch}}(2\leq i\leq k)$. Thus, $R(a,b_i)$ and $A(b_i)$ ($2\leq i\leq k$) can all be added to $\mathcal{G}_{exp}$ in the first iteration of \ref{alg3:updateG}.
 \end{example}
 
-We obtain an \texttt{NC} variant of Algorithm~3 analogously to the process for Algorithm~1. It can be checked that an iteration of Step~2 in Algorithm~3 costs poly-logarithmical time, since the main part is computing $S^*_{\tiny rch}$ by an \texttt{NC} algorithm. Thus, if the number of iterations of Step~2 is upper-bounded by a poly-logarithmical function,
-Algorithm~3 is an \texttt{NC} algorithm. Analogously to $\mathcal{A}_1^{\psi}$, we use $\mathcal{A}_3^{\psi}$ to denote an \texttt{NC} variant. Specifically, for any datalog program $P$, the number of iterations of Step~2 in Algorithm~3 is
+We obtain an \texttt{NC} variant of Algorithm~3 analogously to the process for Algorithm~1. It can be checked that an iteration of \ref{alg3:updateG} in Algorithm~3 costs poly-logarithmical time, since the main part is computing $S^*_{\textit{\tiny rch}}$ by an \texttt{NC} algorithm. Thus, if the number of iterations of \ref{alg3:updateG} is upper-bounded by a poly-logarithmical function,
+Algorithm~3 is an \texttt{NC} algorithm. Analogously to $\mathcal{A}_1^{\psi}$, we use $\mathcal{A}_3^{\psi}$ to denote an \texttt{NC} variant. Specifically, for any datalog program $P$, the number of iterations of \ref{alg3:updateG} in Algorithm~3 is
 bounded by $\psi(|P|)$, where $\psi$ is a poly-logarithmically bounded function.
 
 Based on $\mathcal{A}_3^{\psi}$, we can identify a \texttt{PTD} class $\mathcal{D}_{\mathcal{A}_3^{\psi}}$. One can further check that, for any $\psi$, $\mathcal{D}_{\mathcal{A}_1^{\psi}}\subseteq\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
@@ -269,122 +291,127 @@ For any datalog program $P$, $P\in\mathcal{D}_{\mathcal{A}_3^{\psi}}$ iff $P$ ha
 \section{Undecidability}
 
 We now have two \texttt{PTD} classes $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ and $\mathcal{D}_{\mathcal{A}_3^{\psi}}$
-where $\psi$ is a poly-logarithmically bounded function. Recall that we want to find what kind of ontologies are tractable for parallel materialization. It actually requires us to check, for a given ontology, whether it belongs to some \texttt{PTO} class. The bad news is that, the problem of checking whether a given datalog program belongs to $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ is undecidable (the same for $\mathcal{D}_{\mathcal{A}_3^{\psi}}$). We give the following theorem to show the undecidability of this problem for the previous two \texttt{PTD} classes.
+where $\psi$ is a poly-logarithmically bounded function. Recall that we want to find what kind of ontologies are tractable for parallel materialization. It actually requires us to check, for a given ontology, whether it belongs to some \texttt{PTO} class. The bad news is that the problem of checking whether a given datalog program belongs to $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ or $\mathcal{D}_{\mathcal{A}_3^{\psi}}$ is undecidable, which is shown by the following theorem.
 
-\begin{theorem} Given any datalog program $P$, it is undecidable to check whether, 1) $P\in\mathcal{D}_{\mathcal{A}_1^{\psi}}$, and 2) $P\in\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
+\begin{theorem} Given any datalog program $P$, it is undecidable to check whether, 1) $P\in\mathcal{D}_{\mathcal{A}_1^{\psi}}$ and 2) $P\in\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
 \end{theorem}
 
-The above result indicates that although we have the two \texttt{PTD} classes: $\mathcal{D}_{\mathcal{A}_1^{\psi}}$, and $\mathcal{D}_{\mathcal{A}_3^{\psi}}$, we cannot identify all the datalog
+The above result indicates that although we have the two \texttt{PTD} classes: $\mathcal{D}_{\mathcal{A}_1^{\psi}}$ and $\mathcal{D}_{\mathcal{A}_3^{\psi}}$, we cannot identify all the datalog
 programs that belong to either of them.
 
 
 \section{Identifying Decidable Classes}
 
-In this section, we investigate two specific ontology languages: RDFS and DHL (a datalog rewritable fragment of OWL),
-and identify the ontologies expressed in these two languages that are tractable for parallel materialization. Instead
-of giving an \texttt{NC} algorithm at first, we propose to restrict the usage of vocabularies or terms in RDFS and DHL. In this way, we identify two classes (denoted by $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$). We prove that the algorithm $\mathcal{A}_3^{\psi}$ can handle $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$\footnote{Theorem 4 is given to show that $\mathcal{D}_{rdfs}$ can even be handled by $\mathcal{A}_1^{\psi}$.}. Thus $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$ are also \texttt{PTD} classes according to Definition \ref{def:ptd}. Furthermore, given a
-datalog program $P$, one can decide whether $P$ belongs to either of $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$ based on
-the restrictions of usage. The study of $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$ is motivated by two reasons: 1) An RDFS or DHL ontology can be rewritten into a datalog program. This makes it possible to use the previous results to analyze them; 2) Several popular real datasets are essentially
-built on these two ontology languages, e.g., YAGO and LUBM. Thus our method can be used to analyze practical cases.
+In this section, we investigate the two specific ontology languages RDFS and DHL and identify ontologies expressed in these two languages that are tractable for parallel materialization. Instead
+of first giving an \texttt{NC} algorithm, we propose to restrict the usage of vocabularies or terms in RDFS and DHL. In this way, we identify two classes (denoted by $\mathcal{D}_{\text{rdfs}}$ and $\mathcal{D}_{\text{dhl}}$). We prove that the algorithm $\mathcal{A}_3^{\psi}$ can handle $\mathcal{D}_{\text{rdfs}}$ and $\mathcal{D}_{\text{dhl}}$\footnote{Theorem 4 is given to show that $\mathcal{D}_{\text{rdfs}}$ can even be handled by $\mathcal{A}_1^{\psi}$.}. Thus, $\mathcal{D}_{\text{rdfs}}$ and $\mathcal{D}_{\text{dhl}}$ are also \texttt{PTD} classes according to Definition~\ref{def:ptd}. Furthermore, given a
+datalog program $P$, one can decide whether $P$ belongs to $\mathcal{D}_{\text{rdfs}}$ or $\mathcal{D}_{\text{dhl}}$ based on
+the restrictions of usage. The study of $\mathcal{D}_{\text{rdfs}}$ and $\mathcal{D}_{\text{dhl}}$ is motivated by two reasons: 1) An RDFS or DHL ontology can be rewritten into a datalog program. This makes it possible to use the previous results to analyze them. 2) Several popular real-world datasets are essentially
+built on these two ontology languages, e.g., YAGO and LUBM. Thus, our method can be used to analyze practical cases.
 
-\textbf{RDFS}. In \cite{rdfSemantic},
-a group of rules (denoted by $R_{rdfs}$ here) is proposed to perform materialization of RDFS ontologies.
-The authors of \cite{DBLP:journals/ws/Horst05}
-proved that, in the worst case, the materialization with $R_{rdfs}$ is in $\texttt{NP}$-complete. However, in practical applications, the usage of RDFS vocabularies should be restricted since `illegal' statements may cause ontology
-hijacking \cite{DBLP:journals/ijswis/HoganHP09}. Thus we follow the advices \cite{DBLP:journals/ijswis/HoganHP09}
-of the restricted usage of RDFS vocabularies and
-define $\mathcal{D}_{rdfs}$ as follows:
+\textbf{RDFS}. \citeauthor{rdfSemantic} \shortcite{rdfSemantic} provides
+a group of rules (denoted $R_{\text{rdfs}}$ here) to perform materialization of RDFS ontologies.
+As shown by \citeauthor{DBLP:journals/ws/Horst05} \shortcite{DBLP:journals/ws/Horst05}, materialization with $R_{\text{rdfs}}$ is $\texttt{NP}$-complete. However, in practical applications, the usage of the RDFS vocabulary should be restricted since `illegal' statements may cause ontology
+hijacking \cite{DBLP:journals/ijswis/HoganHP09}. We follow the advice of  \citeauthor{DBLP:journals/ijswis/HoganHP09} to restrict the usage of the RDFS vocabulary accordingly and
+define $\mathcal{D}_{\text{rdfs}}$ as follows:
 
-\begin{definition}\label{def:drdfs} $\mathcal{D}_{rdfs}$ is a class of datalog programs in the form
-of $\langle\mathcal{O}, R_{rdfs}\rangle$, where the usage of vocabularies
-in $\mathcal{O}$ is restricted as follows:
-
-(1) it is not allowed to state that the domain and range of a property is $\small\texttt{\emph{rdf:Property}}$
-or $\small\texttt{\emph{rdfs:Class}}$;
-
-(2) the statements of subclasses of $\small\texttt{\emph{rdf:Property}}$,
-$\small\texttt{\emph{rdfs:Class}}$, $\small\texttt{\emph{rdfs:ContainerMembershipProperty}}$
-and $\small\texttt{\emph{rdfs:Datatype}}$ are not allowed;
-
-(3) it is not allowed to state that $\small\texttt{\emph{rdfs:Property}}$ is a subclass of some class
-(the same for $\small\texttt{\emph{rdfs:Class}}$, $\small\texttt{\emph{rdfs:Literal}}$, $\small\texttt{\emph{rdfs:ContainerMembershipProperty}}$ and $\small\texttt{\emph{rdfs:Datatype}}$);
-it is not allowed to state that $\small\texttt{\emph{rdfs:member}}$ is a sub-property of some property.
+\begin{definition}\label{def:drdfs} $\mathcal{D}_{\text{rdfs}}$ is the class of datalog programs of the form $\langle\mathcal{O}, R_{\text{rdfs}}\rangle$, where the usage of the RDFS vocabulary 
+in $\mathcal{O}$ is restricted such that it is not allowed to:
+\begin{enumerate}
+\item state that the domain and range of a property is {\small\texttt{\emph{rdf:Property}}}
+or {\small\texttt{\emph{rdfs:Class}}};
+\item define subclasses of {\small\texttt{\emph{rdf:Property}}},
+{\small\texttt{\emph{rdfs:Class}}}, {\small\texttt{\emph{rdfs:ContainerMembershipProperty}}} or {\small\texttt{\emph{rdfs:Datatype}}};
+\item state that {\small\texttt{\emph{rdfs:ContainerMembershipProperty}}}, {\small\texttt{\emph{rdfs:Property}}}, {\small\texttt{\emph{rdfs:Class}}}, {\small\texttt{\emph{rdfs:Literal}}} or {\small\texttt{\emph{rdfs:Datatype}}} is a subclass of some class;
+\item state that {\small\texttt{\emph{rdfs:§member}}} is a subproperty of some property.
+\end{enumerate}
 \end{definition}
 
-\begin{theorem} There exists a function $\psi$ s.t. $\mathcal{D}_{rdfs}\subseteq\mathcal{D}_{\mathcal{A}_1^{\psi}}$.
+\begin{theorem} There exists a function $\psi$ s.t. $\mathcal{D}_{\text{rdfs}}\subseteq\mathcal{D}_{\mathcal{A}_1^{\psi}}$.
 \end{theorem}
 
-\textbf{DHL}. DHL \cite{DBLP:conf/www/GrosofHVD03} is essentially based on the description logic $\mathcal{SHOIQ}$
-DL. For any axiom in the form of $C\sqsubseteq D$, $C$ and $D$ can be atomic concepts, or conjunctions ($C\sqcap D$).
-In particular, $C$ can also be a disjunction ($C\sqcup D$) or an existential restriction ($\exists R.C$), while $D$
-can also be a universal restriction ($\forall R.C$). Furthermore, the statements about roles, i.e., role inclusions ($R\sqsubseteq S$), inverse roles ($R\sqsubseteq S^-$), transitivity ($R\circ R\sqsubseteq R$) and role compositions ($R\circ S\sqsubseteq T$), are also allowed in DHL.
+\textbf{DHL}. The ontology language DHL \cite{DBLP:conf/www/GrosofHVD03} is essentially based on the description logic $\mathcal{SHOIQ}$
+DL. 
+% In both languages an atomic name A is a class, and if C and D are classes, then C \sqcap D is also a class. In Lh, if C is a class and R is a property, then \forall R.C is also a class, while in Lb , if D, C are classes and R is a property, then C \sqcup D and \exists R.C are also classes.
+For any axiom of the form $C\sqsubseteq D$, the concepts $C$ and $D$ satisfy the following grammar definitions, where $A$ denotes an atomic concept and $R$ a role:
+%
+  \begin{align*}
+    C_{(i)} ::= & A \mid C_1 \sqcap C_2 \mid C_1 \sqcup C_2 \mid \exists R.C\\
+    D_{(i)} ::= & A \mid D_1 \sqcap D_2 \mid \forall R.D
+  \end{align*}
+%
+% Birte: I tried to make the definition more precise using a grammar.
+% For any axiom in the form of $C\sqsubseteq D$, $C$ and $D$ can be atomic concepts, or conjunctions ($C\sqcap D$).
+% In particular, $C$ can also be a disjunction ($C\sqcup D$) or an existential restriction ($\exists R.C$), while $D$
+% can also be a universal restriction ($\forall R.C$). 
+Furthermore, the statements about roles, i.e., role inclusions ($R\sqsubseteq S$), inverse roles ($R\sqsubseteq S^-$), transitivity ($R\circ R\sqsubseteq R$) and role compositions ($R\circ S\sqsubseteq T$), are also allowed in DHL.
 The assertions in
-an ABox of a DHL ontology are of two forms $C(a)$ and $R(a,b)$, which correspond to the facts
-in a datalog program. Readers can refer to Example~1 for
-the example of datalog rules rewritten from a DHL ontology.
-In the following, we define a class of datalog programs $\mathcal{D}_{dhl}$ and
-show that $\mathcal{D}_{dhl}$ is a \texttt{PTD} class by Theorem 5.
+an ABox of a DHL ontology are of two forms $D(a)$ and $R(a,b)$, which correspond to the facts
+in a datalog program. We refer back to Example~\ref{exp:mg} for an example of datalog rules rewritten from a DHL ontology.
+In the following, we define a class of datalog programs $\mathcal{D}_{\text{dhl}}$ and
+show that $\mathcal{D}_{\text{dhl}}$ is a \texttt{PTD} class in Theorem~5.
 
-\begin{definition}\label{def:ddhl} $\mathcal{D}_{dhl}$ is a class of datalog programs that follows two conditions:
-
-1) each datalog program in $\mathcal{D}_{dhl}$ is rewritten from a DHL ontology;
-
-2) for the rules rewritten from role compositions, only two kinds of rules are allowed: `$R_1(x,z)\leftarrow R_1(x,y),R_2(y,z)$' and `$R_1(x,z)\leftarrow R_2(x,y),R_1(y,z)$'
+\begin{definition}\label{def:ddhl} $\mathcal{D}_{\text{dhl}}$ is a class of datalog programs that follows two conditions:
+\begin{enumerate}
+\item each datalog program in $\mathcal{D}_{\text{dhl}}$ is rewritten from a DHL ontology;
+\item for the rules rewritten from role compositions, only two kinds of rules are allowed: `$R_1(x,z)\leftarrow R_1(x,y),R_2(y,z)$' and `$R_1(x,z)\leftarrow R_2(x,y),R_1(y,z)$'
 where $R_2$ is an EDB predicate.
+\end{enumerate}
+
 \end{definition}
 
-\begin{theorem} There exists a function $\psi$ s.t. $\mathcal{D}_{dhl}\subseteq\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
+\begin{theorem} There exists a function $\psi$ s.t. $\mathcal{D}_{\text{dhl}}\subseteq\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
 \end{theorem}
 
 \section{Practical Usability of Theoretical Results}
 
-In this section, we analyze two well-known datasets: LUBM and YAGO. These two datasets have been widely regarded as large-scale datasets and used in many applications and projects. Based on the analysis of these two datasets, we find that, without importing other data sources, they all belong to
-$\mathcal{D}_{dhl}$.
+In this section, we analyze two well-known datasets: LUBM and YAGO. These two datasets have been widely regarded as large-scale datasets and they are used in many benchmarks, applications and projects. % LUBM is an artificial benchmark dataset and as such not really used in any real application. I added "benchmarks" since otherwise our claim might be misleading
+Based on the analysis of these two datasets, we find that, without importing other data sources, they belong to
+$\mathcal{D}_{\text{dhl}}$.
 
-\textbf{LUBM}. The Lehigh University Benchmark (LUBM) is a famous benchmark in the community of Semantic Web \cite{DBLP:journals/ws/GuoPH05}, and has been widely used to facilitate the evaluation of ontology-based systems in a standard and systematic way. In the latest version\footnote{http://swat.cse.lehigh.edu/projects/lubm/}, there are 48 classes and 32 properties. Most of the statements about classes can be rewritten into datalog rules that are allowed in $\mathcal{D}_{dhl}$. There are five classes that are also defined in the form of $A\sqsubseteq\exists R.B$. If we rewrite this axiom into a logic rule, it should be like:
-\begin{center}
-~~~~~~~~~~~~~~~~~~~$A(x)\rightarrow\exists y(R(x,y)\wedge B(y))$\hfill(1)
-\end{center}
-The rule (1) is obtained by introducing new anonymous constants. This kind of rules are always ignored in
+\textbf{LUBM}. The Lehigh University Benchmark (LUBM) is a popular benchmark in the Semantic Web community \cite{DBLP:journals/ws/GuoPH05} and has been widely used to facilitate the evaluation of ontology-based systems in a standard and systematic way. In the latest version,\footnote{http://swat.cse.lehigh.edu/projects/lubm/} there are 48 classes and 32 properties. Most of the statements about classes can be rewritten into datalog rules that are allowed in $\mathcal{D}_{\text{dhl}}$. Five axioms have, however, the form $A\sqsubseteq\exists R.B$, which requires existentially quantified variables in the rule head when rewriting the axiom into a logic rule:
+\begin{align}
+& A(x)\rightarrow\exists y(R(x,y)\wedge B(y))\label{eq:existsInHead}
+\end{align}
+Rule~\eqref{eq:existsInHead} introduces new anonymous constants. This kind of rule is usually ignored in
 practical reasoning when handling LUBM \cite{DBLP:journals/ws/UrbaniKMHB12,DBLP:conf/semweb/WeaverH09}.
-Furthermore, the statements about properties, such as inverse property statement, can be rewritten into datalog rules allowed in $\mathcal{D}_{dhl}$. In summary, if the rules like (1) are ignored, the materialization of a LUBM dataset can be handled by the algorithm $\mathcal{A}_3^{\psi}$.
+Statements about properties, such as inverse property statements, can be rewritten into datalog rules allowed in $\mathcal{D}_{\text{dhl}}$. In summary, if rules such as~\eqref{eq:existsInHead} are ignored, the materialization of a LUBM dataset can be handled by the algorithm $\mathcal{A}_3^{\psi}$.
 
-\textbf{YAGO}. YAGO\footnote{http://www.mpi-inf.mpg.de/home/} is a huge knowledge base, which is constructed from Wikipedia and WordNet. The latest version YAGO3 \cite{DBLP:conf/cidr/MahdisoltaniBS15} has more than 10 million entities (like persons, organizations, cities, etc.) and contains more than 120 million facts about these entities. In order to balance the expressiveness and computing efficiency, a YAGO-style language, called YAGO \emph{model}, is proposed based on a slight extension of RDFS \cite{DBLP:journals/ws/SuchanekKW08}. In addition to the expressiveness of RDFS, YAGO \emph{model} also allows stating the \emph{transitivity} and \emph{acyclicity} of a property. A group of materialization rules is also given \cite{DBLP:journals/ws/SuchanekKW08}. All the rules are allowed in $\mathcal{D}_{dhl}$. Thus we have that a well-constructed YAGO dataset belongs to $\mathcal{D}_{dhl}$.
+\textbf{YAGO}. The knowledge base YAGO\footnote{http://www.mpi-inf.mpg.de/home/} is constructed from Wikipedia and WordNet and the  latest version YAGO3 \cite{DBLP:conf/cidr/MahdisoltaniBS15} has more than 10 million entities (e.g., persons, organizations, cities, etc.) and contains more than 120 million facts about these entities. In order to balance the expressiveness and computing efficiency, a YAGO-style language, called YAGO \emph{model}, is proposed based on a slight extension of RDFS \cite{DBLP:journals/ws/SuchanekKW08}. In addition to the expressiveness of RDFS, YAGO \emph{model} also allows stating the \emph{transitivity} and \emph{acyclicity} of a property. A group of materialization rules is also given \cite{DBLP:journals/ws/SuchanekKW08}. All the rules are allowed in $\mathcal{D}_{\text{dhl}}$. Thus, we have that a well-constructed YAGO dataset belongs to $\mathcal{D}_{\text{dhl}}$.
 
-The above two datasets model the real world knowledge and turn out to be parallelly tractable for materialization.
+The above two datasets model real world knowledge and turn out to be parallelly tractable for materialization.
 This is also supported from the experimental perspectives \cite{DBLP:journals/ws/UrbaniKMHB12,DBLP:conf/icde/SundaraAKDWCS10}.
 On the other hand, the developers and users can also
-refer to $\mathcal{D}_{rdfs}$ and $\mathcal{D}_{dhl}$ when building their own ontologies.
+refer to $\mathcal{D}_{\text{rdfs}}$ and $\mathcal{D}_{\text{dhl}}$ when building their own ontologies.
 
 \section{Discussions and Related Work}
 
 Parallel reasoning with ontology languages has been extensively studied in the past decade.
 
 The parallel reasoner RDFox \cite{DBLP:conf/aaai/MotikNPHO14} handles reasoning on datalog rewritable ontology languages.
-Algorithm~1 proposed in Section 3 is similar to the main algorithm for RDFox (see \cite{DBLP:conf/aaai/MotikNPHO14}, sections 3 and 4). A thread in RDFox handles several rule instantiations with respect to a fact. Such a thread corresponds to a group of processors in Algorithm~1 that are assigned with the rule instantiations handled by the thread. Thus the materialization of the datalog program in Example~1 is serial on RDFox. We use Algorithm~3 to show that the datalog program in Example~1 is also parallelly tractable, i.e., belonging to $\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
+Algorithm~1 proposed in Section~3 is similar to the main algorithm for RDFox (see \cite[Sections~3 and~4]{DBLP:conf/aaai/MotikNPHO14}). A thread in RDFox handles several rule instantiations with respect to a fact. Such a thread corresponds to a group of processors in Algorithm~1 that are assigned with the rule instantiations handled by the thread. Thus, the materialization of the datalog program in Example~\ref{exp:mg} is serial in RDFox. We use Algorithm~3 to show that the datalog program in Example~\ref{exp:mg} is also parallelly tractable, i.e., belonging to $\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
 
 For RDFS materialization, different parallel techniques and platforms are used. The representative systems are WebPIE \cite{DBLP:journals/ws/UrbaniKMHB12}, Marvin \cite{oren2009marvin} and SAOR \cite{DBLP:journals/ijswis/HoganHP09}.
-The data partition strategies are also studied \cite{DBLP:conf/ISCApdcs/SomaP08,DBLP:conf/semweb/WeaverH09}. Parallel reasoning has also been verified to be available on other OWL fragments, like OWL EL \cite{DBLP:journals/jar/KazakovKS14}, OWL QL \cite{DBLP:conf/dlog/LemboSS13}, and even highly expressive languages \cite{DBLP:conf/otm/LiebigM07,DBLP:conf/dlog/SchlichtS08,DBLP:conf/dlog/WuH12}. Parallelism can also improve the performance of evaluation on non-monotonic logic \cite{Tachmazidis-Stratified-ECAI2012}.
-Unlike the above work, our work does not aim to give parallel reasoning algorithms, but to identify such ontologies
+Data partitioning strategies are also studied \cite{DBLP:conf/ISCApdcs/SomaP08,DBLP:conf/semweb/WeaverH09}. Parallel reasoning is also implemented for other OWL fragments, e.g., OWL~EL \cite{DBLP:journals/jar/KazakovKS14}, OWL~QL \cite{DBLP:conf/dlog/LemboSS13}, and even highly expressive languages \cite{StLG14b,DBLP:conf/otm/LiebigM07,DBLP:conf/dlog/SchlichtS08,DBLP:conf/dlog/WuH12}. Parallelism can also improve the performance of reasoning in non-monotonic logics \cite{Tachmazidis-Stratified-ECAI2012}.
+Unlike the above work, the aim of our work is not to devise an efficient parallel reasoning algorithms, but to identify ontologies
 that are tractable for parallel materialization.
 
-In other related areas, there is also work on studying how to make the target problems tractable in parallel. In the area of logic programming, the works \cite{DBLP:journals/algorithmica/UllmanG88,DBLP:journals/jacm/AfratiP93} focus on logic rules and analyze the cases where reasoning on chain-style rules is in \texttt{NC}. The work of \cite{DBLP:journals/jcst/FanH14} studies the problem of query answering on big data. The authors propose several classes of queries that can lead to \texttt{NC} algorithms on big data.
+In other related areas, there is also work on how to make target problems tractable in parallel. In the area of logic programming, the works of \citeauthor{DBLP:journals/algorithmica/UllmanG88} \shortcite{DBLP:journals/algorithmica/UllmanG88} and \citeauthor{DBLP:journals/jacm/AfratiP93} \shortcite{DBLP:journals/jacm/AfratiP93} focus on logic rules and analyze the cases where reasoning on chain-style rules is in \texttt{NC}. The work of \citeauthor{DBLP:journals/jcst/FanH14} \shortcite{DBLP:journals/jcst/FanH14} studies the problem of query answering on big data. The authors propose several classes of queries that can lead to \texttt{NC} algorithms on big data.
 
 
 \section{Conclusions and Future Work}
 
 In this paper, we studied the problem of finding ontologies such that the materialization over them is parallelly tractable. To this end,
 we first proposed two \texttt{NC} algorithms that perform materialization on datalog rewritable ontology languages.
-Based on these algorithms, we identified the corresponding \emph{parallelly tractable datalog program} (\texttt{PTD}) classes such that materialization on the datalog programs in these classes is in the complexity \texttt{NC}.
-We showed that to decide whether a given datalog program belongs to either of these \texttt{PTD} classes is undecidable. We further studied two specific ontology languages RDFS and DHL, and identified two decidable \texttt{PTD} classes. To verify the usefulness of our theoretical results, we analyzed two well-known datasets, LUBM and YAGO,
+Based on these algorithms, we identified the corresponding \emph{parallelly tractable datalog program} (\texttt{PTD}) classes such that materialization on the datalog programs in these classes is in the complexity class \texttt{NC}.
+We showed that to decide whether a given datalog program belongs to either of these \texttt{PTD} classes is undecidable. We further studied two specific ontology languages, RDFS and DHL, and identified two decidable \texttt{PTD} classes. To verify the usefulness of our theoretical results, we analyzed two well-known datasets, LUBM and YAGO,
 which have a good performance for parallel reasoning. Our analysis shows that YAGO and a
-restricted version of LUBM belong to $\mathcal{D}_{dhl}$.
+slightly restricted version of LUBM indeed belong to the parallely tractable class  $\mathcal{D}_{\text{dhl}}$.
 
-In one of our future works, we will study how to apply theoretical results into practice.
-One idea is to study the impact of the restrictions in Definition 3 and Definition 4 by analyzing more real ontologies,
-for example DBpedia\footnote{http://wiki.dbpedia.org/} and the biomedical ontology SNOMED CT\footnote{http://www.ihtsdo.org/snomed-ct}.
-The other idea is to adapt the optimizations given in Algorithm~3 to existing parallel reasoning algorithms.
-Another line of future work is to extend our results to other OWL languages, e.g., OWL RL.
+In our future work, we will study in detail how to apply the theoretical results in practice.
+One idea is to study the impact of the restrictions in Definition~3 and Definition~4 by analyzing more real-world ontologies,
+for example, DBpedia\footnote{http://wiki.dbpedia.org/} and the biomedical ontology SNOMED CT\footnote{http://www.ihtsdo.org/snomed-ct}.
+Another idea is to adapt the optimizations given in Algorithm~3 to existing parallel reasoning algorithms.
+Finally, we plan to extend our results to other OWL fragments, e.g., OWL~RL.
 
 \clearpage
 

--- a/exploring-v7/exploring.tex
+++ b/exploring-v7/exploring.tex
@@ -204,11 +204,9 @@ $\mathcal{A}_1^{\psi}$ is restricted in the sense that it cannot even work on th
 \section{An Optimized \texttt{NC} Algorithm}
 
 In this section, we optimize Algorithm~1 such that $P_{exp}$
-can be handled. Based on the optimized variant of Algorithm~1, we can identify the other \texttt{PTD} class.
+can be handled. Based on the optimized variant of Algorithm~1, we can identify other \texttt{PTD} classes.
 
-We find that, in the case of Example~1, the construction of a materialization graph can be accelerated.
-In Example~1, $A(b_k)$ would be added to $\mathcal{G}_{exp}$ after \emph{at least} $k$ iterations by performing Algorithm~1. Observe that $A(b_k)$ is reachable from $R(a,b_1)$ through the path $(R(a,b_1),R(a,b_2),...,R(a,b_k))$. On the one hand, each node $R(a,b_i)$ ($2\leq i\leq k$) can be added to $\mathcal{G}_{exp}$ whenever its parent $R(a,b_{i-1})$ is in $\mathcal{G}$, since $R(a,b_i)$ is an SWD node, i.e., $R(a,b_{i-1})$ is the unique implicit parent node of $R(a,b_{i})$ (see the paragraph after Definition 2). On the other hand, $R(a,b_1)$ is initially added to $\mathcal{G}_{exp}$. Thus one can add all the nodes $R(a,b_i)$ ($2\leq i\leq k$) and $A(b_k)$ to $\mathcal{G}_{exp}$ right after $R(a,b_1)$.
-Based on this observation, we can optimize Algorithm~1 using the following strategy:
+For Example~1, the construction of the materialization graph can be accelerated. Using Algorithm~1, $A(b_k)$ is added to $\mathcal{G}_{exp}$ after \emph{at least} $k$ iterations. Observe that $A(b_k)$ is reachable from $R(a,b_1)$ through the path $(R(a,b_1),R(a,b_2),...,R(a,b_k))$. On the one hand, each node $R(a,b_i)$ ($2\leq i\leq k$) can be added to $\mathcal{G}_{exp}$ whenever its parent $R(a,b_{i-1})$ is in $\mathcal{G}$, since $R(a,b_i)$ is an SWD node, i.e., $R(a,b_{i-1})$ is the unique implicit parent node of $R(a,b_{i})$ (see the paragraph after Definition 2). On the other hand, $R(a,b_1)$ is initially added to $\mathcal{G}_{exp}$. Thus, one can add all the nodes $R(a,b_i)$ ($2\leq i\leq k$) and $A(b_k)$ to $\mathcal{G}_{exp}$ right after $R(a,b_1)$. Based on this observation, we optimize Algorithm~1 using the following strategy:
 
 (\textbf{Strategy}) \emph{In every iteration of Step~2, for each SWD node $v$, we add $v$ to $\mathcal{G}$ immediately if $v$ is reachable from some node that has been in $\mathcal{G}$ through a path containing only SWD nodes}.
 
@@ -223,33 +221,33 @@ $(\textbf{\dag})$ \emph{For each rule instantiation $H\leftarrow B_1,..,B_i,..,B
 
 \emph{(2) if in the body, $B_i$ is the unique implicit node and not yet in $\mathcal{G}$, we add \texttt{rch}$(B_i,H)$ to $S_{\tiny rch}$}.\hfill$\Box$
 
-We then compute the transitive closure of \texttt{rch} with respect to $S_{\tiny rch}$. From the transitive closure, we can identify such SWD nodes that can be added to $\mathcal{G}$ in advance. We give the following algorithm to apply the optimization strategy:\\
+We then compute the transitive closure of \texttt{rch} with respect to $S_{\tiny rch}$. From the transitive closure, we can identify such SWD nodes that can be added to $\mathcal{G}$ in advance. The following algorithm applies this optimization strategy:\\
 
-\noindent\texttt{Algorithm~2}. This algorithm accepts two inputs: one is a datalog program $P=\langle\mathcal{O}, R\rangle$, the other one is a partial materialization graph $\mathcal{G}$ that is being constructed from $P$. Then the following steps are performed:
+\noindent\texttt{Algorithm~2}. The algorithm requires two inputs: a datalog program $P=\langle\mathcal{O}, R\rangle$ and a (partial) materialization graph $\mathcal{G}$ that is constructed from $P$. Then the following steps are performed:
 
-(\textbf{\romannumeral1}) the algorithm first computes a \texttt{rch} relation $S_{\tiny rch}$ by following the above process (see $(\textbf{\dag})$).
+(\textbf{\romannumeral1}) Compute a \texttt{rch} relation $S_{\tiny rch}$ by following the above process (see $(\textbf{\dag})$).
 
-(\textbf{\romannumeral2}) the algorithm then computes the transitive closure of $S_{\tiny rch}$ and gets a new one $S^*_{\tiny rch}$.
+% (\textbf{\romannumeral2}) Compute the transitive closure of $S_{\tiny rch}$ and gets a new one $S^*_{\tiny rch}$.
+(\textbf{\romannumeral2}) Compute the transitive closure $S^*_{\tiny rch}$ of $S_{\tiny rch}$.
 
-(\textbf{\romannumeral3}) Finally, $\mathcal{G}$ is updated as follows: for any \texttt{rch}$(B_i,H)\in S_{\tiny rch}$ that corresponds to $H\leftarrow B_1,..,B_i,..,B_n$
-such that \texttt{rch}$(B',H)$,\texttt{rch}$(B'',B_i)\in S^*_{\tiny rch}$ where $B',B''$ are in $\mathcal{G}$; If $H$ is not in $\mathcal{G}$ or $H$ is in $\mathcal{G}$ but has no parent pointing to it, the algorithm adds $H$ and $B_i$ (if $B_i$ is not in $\mathcal{G}$) to $\mathcal{G}$, and creates edges $e(B_1, H),...,e(B_n, H)$ in $\mathcal{G}$. For other statements \texttt{rch}$(B_j,H)\in S_{\tiny rch}$, the algorithm does nothing.\hfill$\Box$\\
+(\textbf{\romannumeral3}) Update $\mathcal{G}$ as follows: for any \texttt{rch}$(B_i,H)\in S_{\tiny rch}$ that corresponds to $H\leftarrow B_1,..,B_i,..,B_n$
+such that \texttt{rch}$(B',H)$,\texttt{rch}$(B'',B_i)\in S^*_{\tiny rch}$ where $B',B''$ are in $\mathcal{G}$; If $H$ is not in $\mathcal{G}$ or $H$ is in $\mathcal{G}$ but has no parent pointing to it, add $H$ and $B_i$ (if $B_i$ is not in $\mathcal{G}$) to $\mathcal{G}$, and create the edges $e(B_1, H),...,e(B_n, H)$ in $\mathcal{G}$. Do nothing for other statements \texttt{rch}$(B_j,H)\in S_{\tiny rch}$.\hfill$\Box$\\
 
-It is well known that there is an \texttt{NC} algorithm for computing transitive closure \cite{DBLP:conf/cie/Allender07}.
-Motivated by this result, we propose a variant of Algorithm~1 based on Algorithm~2.\\
+It is well known that there is an \texttt{NC} algorithm for computing the transitive closure \cite{DBLP:conf/cie/Allender07}. Based on this result and Algorithm~2, we propose a variant of Algorithm~1:\\
 
-\noindent\texttt{Algorithm~3}. Given a datalog program $P=\langle\mathcal{O}, R\rangle$, this algorithm
+\noindent\texttt{Algorithm~3}. Given a datalog program $P=\langle\mathcal{O}, R\rangle$, the algorithm
 returns a materialization graph $\mathcal{G}$ of $P$. Initially $\mathcal{G}$ is empty. The following steps are then performed:
 
-(\emph{Step~1}) All facts in $\mathcal{O}$ are added to $\mathcal{G}$.
+(\emph{Step~1}) Add all facts in $\mathcal{O}$ to $\mathcal{G}$.
 
-(\emph{Step~2}) The algorithm computes $S_{\tiny rch}$ by performing (\textbf{\romannumeral1}) in Algorithm~2; the transitive closure $S^*_{\tiny rch}$ is computed by an \texttt{NC} algorithm (see (\textbf{\romannumeral2}) in Algorithm~2); $\mathcal{G}$ is updated by performing (\textbf{\romannumeral3}) in Algorithm~2.
+(\emph{Step~2}) Compute $S_{\tiny rch}$ by performing (\textbf{\romannumeral1}) in Algorithm~2; use an \texttt{NC} algorithm to compute the transitive closure $S^*_{\tiny rch}$ (see (\textbf{\romannumeral2}) in Algorithm~2); update $\mathcal{G}$ by performing (\textbf{\romannumeral3}) in Algorithm~2.
 
-(\emph{Step~3}) The algorithm iterates Step~2 until there is no node that can be added to $\mathcal{G}$. Then it terminates.\hfill$\Box$\\
+(\emph{Step~3}) If no nodes can be added to $\mathcal{G}$ termine, otherwise iterate Step~2.\hfill$\Box$\\
 
-We give the following lemma to show the correctness of Algorithm~3.
+The following lemma shows the correctness of Algorithm~3.
 
 \begin{lemma}
-Given a datalog program $P=\langle\mathcal{O}, R\rangle$, Algorithm~3 halts and the output $\mathcal{G}$ is a materialization graph of $P$.
+Given a datalog program $P=\langle\mathcal{O}, R\rangle$, Algorithm~3 halts and outputs a materialization graph $\mathcal{G}$ of $P$.
 \end{lemma}
 
 \begin{example}
@@ -257,13 +255,12 @@ We perform Algorithm~3 on the datalog program $P_{exp}$ in Example~1. Initially,
 one can check that \texttt{rch}$(R(a,b_1), R(a,b_i)),$\texttt{rch}$(R(a,b_1), A(b_i))\in S^*_{\tiny rch}(2\leq i\leq k)$. Thus $R(a,b_i)$ and $A(b_i)$ ($2\leq i\leq k$) can all be added to $\mathcal{G}_{exp}$ in the first iteration of Step~2.
 \end{example}
 
-We can obtain the \texttt{NC} variant of Algorithm~3 as what we do for Algorithm~1. It can be checked that a cycle
-of Step~2 in Algorithm~3 costs poly-logarithmical time, since the main part is computing $S^*_{\tiny rch}$ by an \texttt{NC} algorithm. Thus if the number of iterations of Step~2 is upper-bounded by a poly-logarithmical function,
-Algorithm~3 is an \texttt{NC} algorithm. As the same to $\mathcal{A}_1^{\psi}$, we use $\mathcal{A}_3^{\psi}$ to denote an \texttt{NC} variant. Specifically, for any datalog program $P$, the number of iterations of Step~2 in Algorithm~3 is
+We obtain an \texttt{NC} variant of Algorithm~3 analogously to the process for Algorithm~1. It can be checked that an iteration of Step~2 in Algorithm~3 costs poly-logarithmical time, since the main part is computing $S^*_{\tiny rch}$ by an \texttt{NC} algorithm. Thus, if the number of iterations of Step~2 is upper-bounded by a poly-logarithmical function,
+Algorithm~3 is an \texttt{NC} algorithm. Analogously to $\mathcal{A}_1^{\psi}$, we use $\mathcal{A}_3^{\psi}$ to denote an \texttt{NC} variant. Specifically, for any datalog program $P$, the number of iterations of Step~2 in Algorithm~3 is
 bounded by $\psi(|P|)$, where $\psi$ is a poly-logarithmically bounded function.
 
 Based on $\mathcal{A}_3^{\psi}$, we can identify a \texttt{PTD} class $\mathcal{D}_{\mathcal{A}_3^{\psi}}$. One can further check that, for any $\psi$, $\mathcal{D}_{\mathcal{A}_1^{\psi}}\subseteq\mathcal{D}_{\mathcal{A}_3^{\psi}}$.
-The following theorem is given to show that $\mathcal{D}_{\mathcal{A}_3^{\psi}}$ can also be captured by materialization graph.
+The following theorem shows that $\mathcal{D}_{\mathcal{A}_3^{\psi}}$ can also be captured by a materialization graph.
 
 \begin{theorem}
 For any datalog program $P$, $P\in\mathcal{D}_{\mathcal{A}_3^{\psi}}$ iff $P$ has a materialization graph $\mathcal{G}$ such that the number of MWD nodes in each path of $\mathcal{G}$ is upper-bounded by $\psi(|P|)$.


### PR DESCRIPTION
I made several small corrections from Sec. 4 to the end. In particular, the algorithms should contain instructions/commands rather than descriptions of what a step does, e.g., in Alg. 3, Step 1 I now say "(Step 1) Add all facts in O to G." instead of "The algorithm adds all facts in O to G." I rephrased some sentences to shorten them, so the paper is back to the required 6+1 pages and I had enough space to use proper enumerations/descriptions, which have nicer spacing and allow for using labels that can then be referenced. I unified some comma usage (comma after thus and e.g.) and case in the bib file (e.g., upper case for RDFS in the title). I further formalized the definition of DHL since I found the beginning about the conjunctions quite ambiguous. 